### PR TITLE
Fix bug Discord setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,12 @@ The bot will have a token, which you should also save.
 Once you've made the bot, you need to invite it to your server.
 You'll need to do so by constructing a URL like:
 
-`https://discordapp.com/api/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot&permissions=66560`
+`https://discordapp.com/api/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot&permissions=8
 
 Where `${CLIENT_ID}` should be replaced with your application's client id from
 above. For example, if your application's client id is 1234, use the following url:
 
-`https://discordapp.com/api/oauth2/authorize?client_id=1234&scope=bot&permissions=66560`
+`https://discordapp.com/api/oauth2/authorize?client_id=1234&scope=bot&permissions=8`
 
 Open that url in a browser where you are logged into Discord, and you'll see a
 menu letting you add the bot to servers you have access to. Add it to the


### PR DESCRIPTION
Currently, we give the following URL template for giving a bot permissions:

```
https://discordapp.com/api/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot&permissions=66560`
```
This was throwing the following error:
`{client_id": ["Value \"$742897388204720201\" is not snowflake."]}`

Found an [article](https://www.digitaltrends.com/gaming/how-to-make-a-discord-bot/) on setting up a bot that passes the value '8' instead of '66560' as the permissions value. This worked locally. This PR changes the value to '8' in both places it appears. 

@hammadj confirmed in [chat](https://discordapp.com/channels/453243919774253079/454007907663740939/745046374676168804) that we should make this change 'if 8 works', but someone other than me should probably verify that 8 works. 