### PR TITLE
Upgrade to beta-12

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "sourcecred": "0.7.0-beta-7"
+    "sourcecred": "0.7.0-beta-12"
   },
   "scripts": {
     "clean": "rimraf cache site",
@@ -16,7 +16,7 @@
     "graph": "sourcecred graph",
     "score": "sourcecred score",
     "site": "sourcecred site",
-    "serve": "sourcecred admin",
+    "serve": "sourcecred serve",
     "grain": "sourcecred grain"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1668,6 +1668,11 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
+lodash.sortedindex@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortedindex/-/lodash.sortedindex-4.1.0.tgz#3f6417ee20e8b22416ab005bfa16344a0446b448"
+  integrity sha1-P2QX7iDosiQWqwBb+hY0SgRGtEg=
+
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
@@ -2650,10 +2655,10 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcecred@0.7.0-beta-7:
-  version "0.7.0-beta-7"
-  resolved "https://registry.yarnpkg.com/sourcecred/-/sourcecred-0.7.0-beta-7.tgz#c9226e47fa1ca1a55104cffe440fbc5dbdb68350"
-  integrity sha512-t1h9yKLrhaVVHE/AwzlnKZv+vHnclaMcGZU24gZLyrjx1QCimKgk8lztPkBoGGlmDtg38f3KZSzsmbQJhRwOyw==
+sourcecred@0.7.0-beta-12:
+  version "0.7.0-beta-12"
+  resolved "https://registry.yarnpkg.com/sourcecred/-/sourcecred-0.7.0-beta-12.tgz#ce5574012b3a57b2944e6ea8063b29e4c4ee57f2"
+  integrity sha512-HVybspWzuCD+HaoIeaFlmFFmMOIlF2U2muMeoIdtS3V2/S21DRACT6cI5+n/xrVfY3YVIIAczsCaH5Ewf5PJnw==
   dependencies:
     "@material-ui/lab" "^4.0.0-alpha.56"
     aphrodite "^2.4.0"
@@ -2684,6 +2689,7 @@ sourcecred@0.7.0-beta-7:
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
     lodash.sortby "^4.7.0"
+    lodash.sortedindex "^4.1.0"
     object-assign "^4.1.1"
     pako "^1.0.11"
     promise "^8.1.0"


### PR DESCRIPTION
This upgrades the version of SourceCred being used. This also requires
an update to reflect that `sourcecred admin` was renamed to `sourcecred
serve`.

Test plan: Run the following commands:

```
yarn clean && \
yarn load && \
yarn graph && \
yarn score && \
yarn site && \
yarn serve
```

And verify that the site served is functional.

Note: As of beta-11, we now automatically add identities to the ledger
when we run `sourcecred graph`. For now I am not committing the updated
data/ledger.json file, we'll want to decide how to handle it (do we
commit a messy ledger.json file, and tell users to reset it when they
set up their instance?)