### PR TITLE
Setup Grain Distribution action and add README guide

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -1,0 +1,64 @@
+name: Distribute Grain
+on:
+  # A new Cred interval every Sunday. We'll distribute Grain 5 minutes
+  # after the new interval
+  schedule:
+    - cron: 5 0 * * 0 # 00:05 UTC, 16:05 PST
+  push:
+    branches:
+      # allows us to test this workflow, or manually generate distributions
+      # PRSs created from grain-trigger-* branches are targeted
+      # on their immediate base branches, as opposed to master
+      - "grain-trigger-*"
+
+jobs:
+  distribute-grain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Packages 🔧
+        run: |
+          yarn --frozen-lockfile
+
+      - name: Load Data into Graph 🔌
+        run: |
+          yarn load
+          yarn graph
+        env:
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
+
+      - name: Compute Cred 🧮
+        run: yarn score
+
+      - name: Distribute Grain 💸
+        run: yarn grain > grain_output.txt
+
+      - name: Set environment variables
+        id: pr_details
+        run: |
+          echo ::set-env name=PULL_REQUEST_TITLE::"Scheduled grain distribution for week ending $(date +"%B %dth, %Y")"
+          description="This PR was auto-generated on $(date +%d-%m-%Y) \
+            to add the latest grain distribution to our instance.
+
+            $(cat grain_output.txt)"
+          description="${description//'%'/'%25'}"
+          description="${description//$'\n'/'%0A'}"
+          description="${description//$'\r'/'%0D'}"
+          echo "::set-output name=pr_body::$description"
+          rm grain_output.txt
+
+      - name: Create commit and PR for ledger changes
+        id: pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: generated-ledger
+          branch-suffix: timestamp
+          committer: credbot <credbot@users.noreply.github.com>
+          # author appears to be overridden when the default github action
+          # token is used for checkout
+          author: credbot <credbot@users.noreply.github.com>
+          commit-message: update calculated ledger
+          title: ${{ env.PULL_REQUEST_TITLE }}
+          body: ${{ steps.pr_details.outputs.pr_body }}

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Then, run the following commands to update the instance:
 
 - `yarn load [...plugins]` loads the cache. By default, it loads all
   plugins, or it can load only specific plugins if requested.
-- `yarn graph  [...plugins]` regenerates plugin graphs from the cache;
-  these graphs get saved in `output/`
+- `yarn graph` regenerates plugin graphs from the cache;
+  these graphs get saved in `output/`.
 - `yarn score` computes Cred scores, combining data from all the chosen
   plugins
 - `yarn grain` distributes Grain according to the current Cred scores, and the config in `config/grain.json`
@@ -177,7 +177,23 @@ emoji a weight of 10.
 To deactivate a plugin, just remove it from the `bundledPlugins` array in the `sourcecred.json` file.
 You can also remove its `config/plugins/OWNER/NAME` directory for good measure.
 
+### Distributing Grain
 
+This repo contains a GitHub action for distributing grain. It will run every Sunday and create a Pull Request
+with the ledger updated with the new grain balances based on the users cred scores. The amount of grain to get distributed
+every week can be defined in the `config/grain.json` file. There are two different policies that can be used to control
+how the grain gets distributed: 
+- `immediatePerWeek` splits the grain evenly based on everyone's Cred in the last week only.
+- `balancedPerWeek` distributes the grain consistently based on total lifetime cred scores. i.e. it balances
+the distribution of grain with the distribution of total historical cred.
+
+The balanced policy allows SourceCred to reward people retro-actively. e.g. If someone has been historically "overpaid"
+with grain relative to their cred scores, that people will receive less grain in the balanced distribution while people
+who have been "underpaid" relative to their cred will receive more grain.
+
+In SourceCred, we distribute 15000 grain / week with the "balanced" policy and 5000 grain / week with the "immediate"
+policy. The values you use for your community depend on whether you want to optimize for more immediate short term
+action, or for long term incentive alignment, but we recommend using a blend of both.
 
 [Yarn]: https://classic.yarnpkg.com/
 


### PR DESCRIPTION
Copied over the grain distribution action from SourceCred's cred instance and added a guide in the README explaining
how grain distributions work and how to configure them.

Test Plan:
- Ensure the distribute-grain action successfully runs and creates a PR with updated ledger.
- Sanity check README guide on grain distributions