### PR TITLE
Fix default dependencies.json config file

### DIFF
--- a/config/dependencies.json
+++ b/config/dependencies.json
@@ -1,9 +1,8 @@
 [
     {
-        "autoActivateOnIdentityCreation": true,
         "name": "SourceCred",
-        "periods": [
-          {"startTime": "2020-09-20", "weight": 0.05}
-        ]
+        "periods": [],
+        "autoActivateOnIdentityCreation": true,
+        "autoInjectStartingPeriodWeight": 0.05
     }
 ]


### PR DESCRIPTION
Updates the dependencies.json file to match the new API, the current config causes errors when setting up an instance.

With https://github.com/sourcecred/sourcecred/pull/2291, running SourceCred will now set the period to start from 1 week of the user setting up their cred instance.