### PR TITLE
Simplify process for running SourceCred and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ In SourceCred, we distribute 15000 grain / week with the "balanced" policy and 5
 policy. The values you use for your community depend on whether you want to optimize for more immediate short term
 action, or for long term incentive alignment, but we recommend using a blend of both.
 
+### Low-level CLI
+If you want to go deeper, you can access lower-level commands in the sourcecred CLI in the form of: `yarn sourcecred <command>`. 
+For a list of what's available, and what each command does, run `yarn sourcecred help`.
+
 ### Publishing on GitHub pages
 
 Once you've got the instance configured to your satisfaction (see instructions on plugins below),
@@ -150,4 +154,3 @@ You can also remove its `config/plugins/OWNER/NAME` directory for good measure.
 
 
 [Yarn]: https://classic.yarnpkg.com/
-

--- a/README.md
+++ b/README.md
@@ -63,34 +63,45 @@ cp .env.example .env
 for each plugin and then paste them into the `.env` file after the `=` sign.
 
 
-5. Run the following commands to update the instance:
+5. Use the following commands to run your instance locally:
 
-- `yarn load` loads the data from each plugin into the cache
-- `yarn graph` regenerates plugin graphs from the cache; these graphs get saved in `output/`.
-- `yarn score` computes Cred scores, combining data from all the chosen plugins
-- `yarn grain` distributes Grain according to the current Cred scores, and the config in `config/grain.json`
+**Load Data**
 
-**Generate the frontend:**
+- `yarn load` loads the data from each plugin into the cache. Run this anytime you want to re-load the data from 
+your plugins.
 
-- `yarn site`
+**Run SourceCred**
+- `yarn start` creates the graph, computes cred scores and runs the front end interface which you can access at `localhost:6006`
+in your browser.
 
-**Run the frontend:**
-
-- `yarn serve`
+**Clear Cache**
 
 
-If you want to clear the cached data, you can do so via:
-
-- `yarn clean` 
-
-Running `yarn clean` is a good idea if any plugins fail to load.
+- `yarn clean` will clear any cached data that was loaded by the plugins. You can run this if any plugins fail to load. Run `yarn load` after this to re-load the data.
 
 If you want to restart from a clean slate and remove all the generated graphs, you can do so via:
-
 - `yarn clean-all` 
 
-Run `yarn clean-all` if the `yarn graph` command fails due to a change in the config or breaking changes in a new version of SourceCred.
-**Warning**: If you don't have credentials for every plugin, you might not be able to regenerate parts of the graph.
+Run `yarn clean-all` if the `yarn start` command fails due to a change in the config or breaking changes in a new version of SourceCred.
+
+### Distributing Grain
+- `yarn grain` distributes Grain according to the current Cred scores, and the config in `config/grain.json`. 
+
+This repo also contains a GitHub action for automatically distributing grain. It will run every Sunday and create a Pull Request
+with the ledger updated with the new grain balances based on the users cred scores. The amount of grain to get distributed
+every week can be defined in the `config/grain.json` file. There are two different policies that can be used to control
+how the grain gets distributed: 
+- `immediatePerWeek` splits the grain evenly based on everyone's Cred in the last week only.
+- `balancedPerWeek` distributes the grain consistently based on total lifetime cred scores. i.e. it balances
+the distribution of grain with the distribution of total historical cred.
+
+The balanced policy allows SourceCred to reward people retro-actively. e.g. If someone has been historically "overpaid"
+with grain relative to their cred scores, that people will receive less grain in the balanced distribution while people
+who have been "underpaid" relative to their cred will receive more grain.
+
+In SourceCred, we distribute 15000 grain / week with the "balanced" policy and 5000 grain / week with the "immediate"
+policy. The values you use for your community depend on whether you want to optimize for more immediate short term
+action, or for long term incentive alignment, but we recommend using a blend of both.
 
 ### Publishing on GitHub pages
 
@@ -136,23 +147,7 @@ The full instructions for setting up the Discord plugin can be found in the [Dis
 To deactivate a plugin, just remove it from the `bundledPlugins` array in the `sourcecred.json` file.
 You can also remove its `config/plugins/OWNER/NAME` directory for good measure.
 
-### Distributing Grain
 
-This repo contains a GitHub action for distributing grain. It will run every Sunday and create a Pull Request
-with the ledger updated with the new grain balances based on the users cred scores. The amount of grain to get distributed
-every week can be defined in the `config/grain.json` file. There are two different policies that can be used to control
-how the grain gets distributed: 
-- `immediatePerWeek` splits the grain evenly based on everyone's Cred in the last week only.
-- `balancedPerWeek` distributes the grain consistently based on total lifetime cred scores. i.e. it balances
-the distribution of grain with the distribution of total historical cred.
-
-The balanced policy allows SourceCred to reward people retro-actively. e.g. If someone has been historically "overpaid"
-with grain relative to their cred scores, that people will receive less grain in the balanced distribution while people
-who have been "underpaid" relative to their cred will receive more grain.
-
-In SourceCred, we distribute 15000 grain / week with the "balanced" policy and 5000 grain / week with the "immediate"
-policy. The values you use for your community depend on whether you want to optimize for more immediate short term
-action, or for long term incentive alignment, but we recommend using a blend of both.
 
 [Yarn]: https://classic.yarnpkg.com/
 

--- a/package.json
+++ b/package.json
@@ -13,10 +13,7 @@
     "clean": "rimraf cache site",
     "clean-all": "yarn clean && rimraf output",
     "load": "dotenv sourcecred load",
-    "graph": "dotenv sourcecred graph",
-    "score": "sourcecred score",
-    "site": "sourcecred site",
-    "serve": "sourcecred serve",
+    "start": "dotenv sourcecred go --no-load && sourcecred site && sourcecred serve",
     "grain": "sourcecred grain"
   },
   "devDependencies": {


### PR DESCRIPTION
Reduced the 5 commands needed to run a SC instance down to 2 commands. Based on my experience running an instance and helping others run an instance, the only two things they really want to do are "load the data" and "run SourceCred". Having separate `site` and `serve` command is just leaking implementation details to the user, and the graph/score/site commands run fast enough to group them together into the `yarn start` command. This also limits the chance that the user updates the weights but forgets to run graph/score before running site/serve and gets frustrated or confused as to why their Cred scores aren't updating.

I also relocated the distributing grain instructions to be co-located with the grain command instructions instead of being at the bottom of the README.

Test Plan: Follow the new instructions in the README for running the instance and ensure that
everything works without errors.