### PR TITLE
Cleanup command and improve instructions for reloading data

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,11 @@ for each plugin and then paste them into the `.env` file after the `=` sign.
 your plugins.
 
 **Run SourceCred**
-- `yarn start` creates the graph, computes cred scores and runs the front end interface which you can access at `localhost:6006`
+- `yarn start` creates the cred graph, computes cred scores and runs the front end interface which you can access at `localhost:6006`
 in your browser.
+
+NOTE: this command will not load any new data from Discord / GitHub / Discourse, etc. If you want to re-load
+all the latest user activity, run `yarn load` again.
 
 **Clear Cache**
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf cache site",
     "clean-all": "yarn clean && rimraf output",
     "load": "dotenv sourcecred load",
-    "start": "dotenv sourcecred go --no-load && sourcecred site && sourcecred serve",
+    "start": "dotenv sourcecred go --no-load && sourcecred serve",
     "grain": "sourcecred grain"
   },
   "devDependencies": {


### PR DESCRIPTION
Instructions weren't clean on when and why users should run the `yarn load` command again. This gives more context to the commands and explains more explicitly what yarn start doesn't do.

Also removed redundant command in `yarn start`