### PR TITLE
Update github action for new CLI commands

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -25,20 +25,15 @@ jobs:
       - name: Install Packages 🔧
         run: yarn --frozen-lockfile
 
-      - name: Load Data into Graph 🔌
-        run: |
-          yarn load
-          yarn graph
+      - name: Load Data and Compute Cred 🧮
+        run: yarn sourcecred go
         env:
           SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
 
-      - name: Compute Cred 🧮
-        run: yarn score
-
       - name: Generate Frontend 🏗
         run: |
-          yarn site
+          yarn sourcecred site
           rm -rf ./site/{output,data,config,sourcecred.json}
           cp -r ./{output,data,config,sourcecred.json} ./site/
 


### PR DESCRIPTION
fixes #25

The package.json no longer has the commands that are being used in the Github Action workflow.
This PR updates the workflow file to use the sourcecred go command instead

Test Plan: Ran the command locally and it succeeded, will update the MetaGame instance with this to ensure it works in prod