### PR TITLE
Remove deprecated github action set-env command

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set environment variables
         id: pr_details
         run: |
-          echo ::set-env name=PULL_REQUEST_TITLE::"Scheduled grain distribution for week ending $(date +"%B %dth, %Y")"
+          echo "PULL_REQUEST_TITLE=Scheduled grain distribution for week ending $(date +"%B %dth, %Y")" >> $GITHUB_ENV
           description="This PR was auto-generated on $(date +%d-%m-%Y) \
             to add the latest grain distribution to our instance.
 


### PR DESCRIPTION
test plan: The grain distribution should succeed and there should be no
error citing this update:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/