### PR TITLE
Update distribute-grain action to utilize updated CLI

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -21,16 +21,11 @@ jobs:
         run: |
           yarn --frozen-lockfile
 
-      - name: Load Data into Graph 🔌
-        run: |
-          yarn load
-          yarn graph
+      - name: Load Data and Compute Cred 🧮
+        run: yarn sourcecred go
         env:
           SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
-
-      - name: Compute Cred 🧮
-        run: yarn score
 
       - name: Distribute Grain 💸
         run: yarn grain > grain_output.txt


### PR DESCRIPTION
test plan: diff with the distribute-grain.yml file in the
sourcecred/cred repo should be identical, except for line 60, the
reviewers param in the sourcecred/cred repo