### PR TITLE
Make automatic grain distribution default

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -44,16 +44,31 @@ jobs:
           echo "::set-output name=pr_body::$description"
           rm grain_output.txt
 
-      - name: Create commit and PR for ledger changes
-        id: pr
-        uses: peter-evans/create-pull-request@v3
-        with:
-          branch: generated-ledger
-          branch-suffix: timestamp
-          committer: credbot <credbot@users.noreply.github.com>
-          # author appears to be overridden when the default github action
-          # token is used for checkout
-          author: credbot <credbot@users.noreply.github.com>
-          commit-message: update calculated ledger
-          title: ${{ env.PULL_REQUEST_TITLE }}
-          body: ${{ steps.pr_details.outputs.pr_body }}
+      # This commits grain distributions directly to main
+      - name: Commit ledger changes
+        run: |
+          git config user.name 'credbot'
+          git config user.email 'credbot@users.noreply.github.com'
+          git add data/ledger.json
+          git commit --allow-empty -m '${{ env.PULL_REQUEST_TITLE }}' -m '${{ steps.pr_details.outputs.pr_body }}'
+          
+      - name: Push Ledger
+        run: |
+          git push
+
+      # If you would rather have a manual approval step using a PR,
+      # use this instead:
+      #
+      # - name: Create commit and PR for ledger changes
+      #   id: pr
+      #   uses: peter-evans/create-pull-request@v3
+      #   with:
+      #     branch: generated-ledger
+      #     branch-suffix: timestamp
+      #     committer: credbot <credbot@users.noreply.github.com>
+      #     # author appears to be overridden when the default github action
+      #     # token is used for checkout
+      #     author: credbot <credbot@users.noreply.github.com>
+      #     commit-message: update calculated ledger
+      #     title: ${{ env.PULL_REQUEST_TITLE }}
+      #     body: ${{ steps.pr_details.outputs.pr_body }}


### PR DESCRIPTION
# Description
This makes commit-to-main the default grain distribution behavior for new instances. However, it also leaves the manual-approval behavior in comments so that new instance maintainers can easily choose their desired behavior. This PR will not affect existing instances.

# Test plan
https://github.com/sourcecred/cred/pull/209