### PR TITLE
Add package.json to gh-pages deployment

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           yarn sourcecred site
           rm -rf ./site/{output,data,config,sourcecred.json}
-          cp -r ./{output,data,config,sourcecred.json} ./site/
+          cp -r ./{output,data,config,sourcecred.json,package.json} ./site/
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1


### PR DESCRIPTION
This allows serving the gh-pages branch, in order to easily test against prod data. See https://github.com/sourcecred/cred/pull/247 for details and test plan.