### PR TITLE
Update start command to not re-load data

### DIFF
--- a/config/plugins/sourcecred/discourse/config.json
+++ b/config/plugins/sourcecred/discourse/config.json
@@ -1,1 +1,14 @@
-{"serverUrl": "https://sourcecred-test.discourse.group"}
+{
+  "serverUrl": "https://forum.makerdao.com",
+  "weights": {
+    "categoryWeights": {
+     "5": 1,
+     "36": 1
+    },
+    "defaultCategoryWeight": 1,
+    "defaultTagWeight": 1,
+    "tagWeights": {
+      "sourcecred": 1
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "sourcecred": "^0.7.7"
+    "sourcecred": "^0.8.0"
   },
   "scripts": {
     "clean": "rimraf cache site",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf cache site",
     "clean-all": "yarn clean && rimraf output",
     "load": "dotenv sourcecred load",
-    "start": "dotenv sourcecred go --no-load && sourcecred serve",
+    "start": "dotenv -- sourcecred go --no-load && sourcecred serve",
     "grain": "sourcecred grain"
   },
   "devDependencies": {

--- a/sourcecred.json
+++ b/sourcecred.json
@@ -1,3 +1,3 @@
 {
-  "bundledPlugins": []
+  "bundledPlugins": ["sourcecred/discourse"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2792,10 +2792,10 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-sourcecred@^0.7.7:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/sourcecred/-/sourcecred-0.7.7.tgz#f7ea11cf823bef031fb24a905133d5aa75430b9e"
-  integrity sha512-p6eZuR6vjBpE1Fj15cXW8Z6oMgCxJa7H/THnkgTTLbNuZ4VGx8s3O0HgodQawnHsU/eLtSC8sonpNiR6psjIgA==
+sourcecred@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/sourcecred/-/sourcecred-0.8.0.tgz#9117ac32ea96eab739e9d8d12405eb0148a508de"
+  integrity sha512-hT5bdxc4UfhZh/4tXrA0yS5LCCvySuvF3eHNvisUltVbi4jGXrnsKsXDEZzDUp0Kbr4l6Tuod35RrAQpqEap+w==
   dependencies:
     "@material-ui/lab" "^4.0.0-alpha.56"
     aphrodite "^2.4.0"


### PR DESCRIPTION
The start command was re-loading, data, even though it's not supposed to. This made it impossible to re-generate the graph without re-loading data (too time-consuming for most workflows). 

This PR implements a change suggested by @blueridger in #tech-support ([link](https://discord.com/channels/453243919774253079/718263631158050896/827683756793790486)), which worked for me locally. 

### Test Plan

1. On an existing instance, run `yarn load` (if data not already loaded)
2. Run `yarn start`

The start command should recalculate graph, scores, and run a local instance, without re-loading data. 

P.S. My fix worked locally on OSX Mojave 10.14.6
