### PR TITLE
Update start command to not re-load data

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf cache site",
     "clean-all": "yarn clean && rimraf output",
     "load": "dotenv sourcecred load",
-    "start": "dotenv sourcecred go --no-load && sourcecred serve",
+    "start": "dotenv -- sourcecred go --no-load && sourcecred serve",
     "grain": "sourcecred grain"
   },
   "devDependencies": {


### PR DESCRIPTION
The start command was re-loading, data, even though it's not supposed to. This made it impossible to re-generate the graph without re-loading data (too time-consuming for most workflows). 

This PR implements a change suggested by @blueridger in #tech-support ([link](https://discord.com/channels/453243919774253079/718263631158050896/827683756793790486)), which worked for me locally. 

### Test Plan

1. On an existing instance, run `yarn load` (if data not already loaded)
2. Run `yarn start`

The start command should recalculate graph, scores, and run a local instance, without re-loading data. 

P.S. My fix worked locally on OSX Mojave 10.14.6