### PR TITLE
Use user-provided github token to support private repos

### DIFF
--- a/.github/workflows/distribute-grain.yml
+++ b/.github/workflows/distribute-grain.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Load Data and Compute Cred 🧮
         run: yarn sourcecred go
         env:
-          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
 
       - name: Distribute Grain 💸

--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -28,14 +28,14 @@ jobs:
       - name: Load Data and Compute Cred 🧮
         run: yarn sourcecred go
         env:
-          SOURCECRED_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SOURCECRED_GITHUB_TOKEN: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}
 
       - name: Generate Frontend 🏗
         run: |
           yarn sourcecred site
           rm -rf ./site/{output,data,config,sourcecred.json}
-          cp -r ./{output,data,config,sourcecred.json,package.json} ./site/
+          cp -r ./{output,data,config,sourcecred.json,package.json,yarn.lock} ./site/
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ The GitHub plugin loads GitHub repositories.
 You can specify the repositories to load in
 `config/plugins/sourcecred/github/config.json`.
 
-The Github Action automatically has its own GITHUB_TOKEN, but if you need to load data from the 
-GitHub plugin locally, you must have a GitHub API key in your `.env` file as
+In order for SourceCred to access your GitHub repos, 
+you must have a GitHub API key in your `.env` file as
 `SOURCECRED_GITHUB_TOKEN=<token>` (copy the `.env.example` file for reference). The key should be read-only without any special
 scopes or permissions (unless you are loading a private GitHub repository, in which case
 the key needs access to your private repositories).
+You will also need to add it to your GitHub Action secrets.
 
 You can generate a GitHub API key [here](https://github.com/settings/tokens).
 


### PR DESCRIPTION
Since the load step was using the default actions token, it did not have access to private repos, which broke the `load` step when an instance tried to include private repos using our github plugin.

# Test plan
https://github.com/blueridger/ballena-cred/runs/2611875978?check_suite_focus=true#step:4:217