### PR TITLE
add analysis command in the github action

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -26,7 +26,9 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Load Data and Compute Cred 🧮
-        run: yarn sourcecred go
+        run: |
+          yarn sourcecred go
+          yarn sourcecred analysis
         env:
           SOURCECRED_GITHUB_TOKEN: ${{ secrets.SOURCECRED_GITHUB_TOKEN }}
           SOURCECRED_DISCORD_TOKEN: ${{ secrets.SOURCECRED_DISCORD_TOKEN }}


### PR DESCRIPTION
The footprint is small, and it is used by metagov's instance heavily, and I think it might be a simple api to read data from the SC instance through other modules